### PR TITLE
XSS Vulnerability

### DIFF
--- a/includes/stats.php
+++ b/includes/stats.php
@@ -8,6 +8,7 @@ die;
 }
 $alias = str_replace("-","",$alias);
 $url   = get_url($alias);
+$url   = htmlspecialchars($url);
 $result = mysql_query("SELECT * from ".DB_PREFIX."urls WHERE BINARY alias='$alias' OR code='$alias'");
 $num_rows = mysql_num_rows($result);
 if ($num_rows < 1) {


### PR DESCRIPTION
When outputting the URL on the stats page, no escaping is used. This
presents a vulnerability for XSS (cross site scripting) attacks.
htmlspecialchars($url) will (hopefully) prevent any nefarious activity.
(see http://lop.li/lzKgP- for an example of this vulnerability in
practice)
